### PR TITLE
Differ page a bit to reassure we handle multiple identical page objets

### DIFF
--- a/src/test/java/mkl/testarea/pdfbox2/merge/OptimizeAfterMerge.java
+++ b/src/test/java/mkl/testarea/pdfbox2/merge/OptimizeAfterMerge.java
@@ -107,6 +107,15 @@ public class OptimizeAfterMerge {
      * @see #testOptimizeDummy()
      */
     public void optimize(PDDocument pdDocument) throws IOException {
+
+        // differ page a bit to reassure we handle multiple identical page objets
+        for (int i = 0; i < pdDocument.getPages().getCount(); i++) {
+            PDPage page = pdDocument.getPages().get(i);
+            COSDictionary customDict = new COSDictionary();
+            customDict.setInt("CustomCounter", i + 1);
+            page.getCOSObject().setItem("CustomCounterEntry", customDict);
+        }
+        
         Map<COSBase, Collection<Reference>> complexObjects = findComplexObjects(pdDocument);
         for (int pass = 0; ; pass++) {
             int merges = mergeDuplicates(complexObjects);


### PR DESCRIPTION
Make optimize method less agressive to fix issue when page are identical. For that we make all pages of a PdDocument different by adding custom entry to the page dictionary (page counter). Result: file output will be a few bytes larger.